### PR TITLE
feat(approval): auto-approve bash when sandbox is enabled

### DIFF
--- a/.changeset/sandbox-auto-approve-bash.md
+++ b/.changeset/sandbox-auto-approve-bash.md
@@ -2,4 +2,4 @@
 "@flemma-dev/flemma.nvim": minor
 ---
 
-Auto-approve bash tool when sandbox is enabled and a backend is available. A new resolver at priority 50 approves bash calls when sandboxing is active, so sandboxed sessions run without manual approval prompts by default. Users can opt out via `sandbox.auto_approve = false` in config or frontmatter, or by excluding bash from auto-approval in frontmatter (`auto_approve:remove("bash")`).
+Auto-approve bash tool when sandbox is enabled and a backend is available. A new resolver at priority 50 approves bash calls when sandboxing is active, so sandboxed sessions run without manual approval prompts by default. Users can opt out via `tools.auto_approve_sandboxed = false` in config, or by excluding bash from auto-approval in frontmatter (`auto_approve:remove("bash")`).

--- a/.changeset/sandbox-auto-approve-bash.md
+++ b/.changeset/sandbox-auto-approve-bash.md
@@ -1,0 +1,5 @@
+---
+"@flemma-dev/flemma.nvim": minor
+---
+
+Auto-approve bash tool when sandbox is enabled and a backend is available. A new resolver at priority 50 approves bash calls when sandboxing is active, so sandboxed sessions run without manual approval prompts by default. Users can opt out via `sandbox.auto_approve = false` in config or frontmatter, or by excluding bash from auto-approval in frontmatter (`auto_approve:remove("bash")`).

--- a/.changeset/sandbox-auto-approve-bash.md
+++ b/.changeset/sandbox-auto-approve-bash.md
@@ -2,4 +2,4 @@
 "@flemma-dev/flemma.nvim": minor
 ---
 
-Auto-approve bash tool when sandbox is enabled and a backend is available. A new resolver at priority 50 approves bash calls when sandboxing is active, so sandboxed sessions run without manual approval prompts by default. Users can opt out via `tools.auto_approve_sandboxed = false` in config, or by excluding bash from auto-approval in frontmatter (`auto_approve:remove("bash")`).
+Auto-approve bash tool when sandbox is enabled and a backend is available. A new resolver at priority 25 approves bash calls when sandboxing is active, so sandboxed sessions run without manual approval prompts by default. Users can opt out via `tools.auto_approve_sandboxed = false` in config, or by excluding bash from auto-approval in frontmatter (`auto_approve:remove("bash")`).

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -156,6 +156,44 @@ The boolean shorthand (`flemma.opt.sandbox = true`) expands to `{ enabled = true
 
 ---
 
+## Auto-approval of sandboxed tools
+
+When the sandbox is enabled and a backend is available, Flemma automatically approves tool calls for tools that declare the `"can_auto_approve_if_sandboxed"` capability. Currently only the built-in `bash` tool declares this capability. This means sandboxed sessions run without manual approval prompts for bash by default — the sandbox provides the safety boundary instead.
+
+The auto-approval resolver sits at priority 25 in the [approval chain](tools.md#approval-resolvers), below config (100), frontmatter (90), and the community default (50). Explicit user preferences always win.
+
+### Opting out
+
+Disable sandbox-based auto-approval globally:
+
+```lua
+require("flemma").setup({
+  tools = {
+    auto_approve_sandboxed = false,  -- always require manual approval, even when sandboxed
+  },
+})
+```
+
+Or exclude specific tools per-buffer in frontmatter:
+
+````lua
+```lua
+flemma.opt.tools.auto_approve = { "$default" }
+flemma.opt.tools.auto_approve:remove("bash")
+```
+````
+
+### Requirements
+
+All three conditions must be met for sandbox auto-approval to activate:
+
+1. **`tools.auto_approve` is configured** — the user has opted into some form of auto-approval
+2. **Sandbox is enabled and available** — `sandbox.enabled = true`, no runtime disable override, and a backend (e.g., `bwrap`) is installed and functional
+
+If any condition is unmet, the resolver yields (`nil`) and the chain continues to the next resolver.
+
+---
+
 ## Runtime commands
 
 Toggle sandboxing at runtime without changing your config:

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -555,14 +555,17 @@ Flemma uses a priority-based resolver chain to decide whether a tool call should
 
 Built-in resolvers are registered during `setup()`:
 
-| Priority | Name                              | Source                                                      |
-| -------- | --------------------------------- | ----------------------------------------------------------- |
-| 100      | `urn:flemma:approval:config`      | Global `tools.auto_approve` from config (list or function)  |
-| 100      | `<module.path>`                   | Per-module resolver from `tools.auto_approve` module path   |
-| 90       | `urn:flemma:approval:frontmatter` | Per-buffer `flemma.opt.tools.auto_approve` from frontmatter |
-| 0        | `urn:flemma:approval:catch-all`   | Only when `tools.require_approval = false`                  |
+| Priority | Name                              | Source                                                                                                   |
+| -------- | --------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| 100      | `urn:flemma:approval:config`      | Global `tools.auto_approve` from config (list or function)                                               |
+| 100      | `<module.path>`                   | Per-module resolver from `tools.auto_approve` module path                                                |
+| 90       | `urn:flemma:approval:frontmatter` | Per-buffer `flemma.opt.tools.auto_approve` from frontmatter                                              |
+| 25       | `urn:flemma:approval:sandbox`     | Auto-approve tools with `can_auto_approve_if_sandboxed` capability when sandbox is enabled and available |
+| 0        | `urn:flemma:approval:catch-all`   | Only when `tools.require_approval = false`                                                               |
 
 Third-party plugins register at the default priority of 50. Set `priority` higher to run before built-in resolvers (e.g., 200 to override config), or lower to act as a fallback.
+
+The sandbox resolver (priority 25) auto-approves tools that declare `"can_auto_approve_if_sandboxed"` in their `capabilities` array when three conditions are met: `tools.auto_approve` is configured, the sandbox is enabled, and a backend is available. Currently only the built-in `bash` tool declares this capability. Disable with `tools.auto_approve_sandboxed = false` in config, or exclude specific tools per-buffer with `auto_approve:remove("bash")` in frontmatter.
 
 ### Registering a resolver
 

--- a/lua/flemma/config.lua
+++ b/lua/flemma/config.lua
@@ -74,6 +74,7 @@
 
 ---@class flemma.config.SandboxConfig
 ---@field enabled boolean Master switch (default: true)
+---@field auto_approve? boolean Auto-approve tools that run inside the sandbox (default: true). Set false to always require manual approval even when sandboxed.
 ---@field backend? string "auto" = detect quietly, "required" = detect and warn if none, or explicit name (default: "auto")
 ---@field policy? flemma.config.SandboxPolicy
 ---@field backends? table<string, table> Per-backend config
@@ -284,6 +285,7 @@ return {
   },
   sandbox = {
     enabled = true, -- Enable filesystem sandboxing
+    auto_approve = true, -- Auto-approve tools that run inside the sandbox (set false to require manual approval)
     backend = "auto", -- "auto" detects the best available backend; set explicitly to force one
     policy = {
       rw_paths = { "$CWD", "$FLEMMA_BUFFER_PATH", "/tmp" }, -- Read-write paths (all others are read-only)

--- a/lua/flemma/config.lua
+++ b/lua/flemma/config.lua
@@ -74,7 +74,6 @@
 
 ---@class flemma.config.SandboxConfig
 ---@field enabled boolean Master switch (default: true)
----@field auto_approve? boolean Auto-approve tools that run inside the sandbox (default: true). Set false to always require manual approval even when sandboxed.
 ---@field backend? string "auto" = detect quietly, "required" = detect and warn if none, or explicit name (default: "auto")
 ---@field policy? flemma.config.SandboxPolicy
 ---@field backends? table<string, table> Per-backend config
@@ -97,6 +96,7 @@
 ---@class flemma.config.ToolsConfig
 ---@field require_approval boolean
 ---@field auto_approve? flemma.config.AutoApprove
+---@field auto_approve_sandboxed? boolean Auto-approve tools that run inside the sandbox (default: true). Set false to always require manual approval even when sandboxed.
 ---@field presets? table<string, flemma.tools.PresetDefinition> Named approval presets
 ---@field autopilot flemma.config.AutopilotConfig
 ---@field default_timeout integer
@@ -243,6 +243,7 @@ return {
   tools = {
     require_approval = true, -- Require user approval before executing tool calls (two-step <C-]> flow)
     auto_approve = { "$default" }, -- Tools that bypass approval: string[] of tool/preset names, or function(tool_name, input, context) → true|false|"deny"
+    auto_approve_sandboxed = true, -- Auto-approve tools that run inside the sandbox (set false to require manual approval)
     presets = {}, -- Named approval presets (override built-ins or add new ones with "$name" keys)
     autopilot = {
       enabled = true, -- Auto-execute approved tools and re-send when resolved
@@ -285,7 +286,6 @@ return {
   },
   sandbox = {
     enabled = true, -- Enable filesystem sandboxing
-    auto_approve = true, -- Auto-approve tools that run inside the sandbox (set false to require manual approval)
     backend = "auto", -- "auto" detects the best available backend; set explicitly to force one
     policy = {
       rw_paths = { "$CWD", "$FLEMMA_BUFFER_PATH", "/tmp" }, -- Read-write paths (all others are read-only)

--- a/lua/flemma/tools/approval.lua
+++ b/lua/flemma/tools/approval.lua
@@ -366,6 +366,11 @@ function M.setup()
     priority = 25,
     description = "Auto-approve sandboxed tools when sandbox is enabled with an available backend",
     resolve = function(tool_name, _input, context)
+      -- Cheapest check first: config-level opt-out (tools.auto_approve_sandboxed)
+      if tools_config and tools_config.auto_approve_sandboxed == false then
+        return nil
+      end
+
       -- Only handle tools that execute inside the sandbox
       if tool_name ~= "bash" then
         return nil
@@ -377,12 +382,9 @@ function M.setup()
         return nil
       end
 
-      -- Check the config-level opt-out (tools.auto_approve_sandboxed)
-      if tools_config and tools_config.auto_approve_sandboxed == false then
-        return nil
-      end
-
-      -- Verify sandbox is enabled and a backend is actually available
+      -- Verify sandbox is enabled (respects runtime override from :Flemma
+      -- sandbox:disable and frontmatter sandbox options) and a backend is
+      -- actually available (same check as :Flemma status)
       local sandbox = require("flemma.sandbox")
       if not sandbox.is_enabled(context.opts) then
         return nil

--- a/lua/flemma/tools/approval.lua
+++ b/lua/flemma/tools/approval.lua
@@ -358,12 +358,12 @@ function M.setup()
 
   -- Sandbox-aware auto-approval: when sandboxing is enabled and a backend is
   -- available, auto-approve tools that execute inside the sandbox (currently: bash).
-  -- Priority 50: below config (100) and frontmatter (90) so explicit user
-  -- preferences always win, but above the catch-all (0).
-  -- Checks are deferred to resolve time so runtime overrides and frontmatter
-  -- sandbox options are respected per-call.
+  -- Priority 25: below config (100), frontmatter (90), and the community default (50)
+  -- so both explicit user preferences and third-party resolvers win. Above the
+  -- catch-all (0). Checks are deferred to resolve time so runtime overrides and
+  -- frontmatter sandbox options are respected per-call.
   register_entry("urn:flemma:approval:sandbox", {
-    priority = DEFAULT_PRIORITY,
+    priority = 25,
     description = "Auto-approve sandboxed tools when sandbox is enabled with an available backend",
     resolve = function(tool_name, _input, context)
       -- Only handle tools that execute inside the sandbox

--- a/lua/flemma/tools/approval.lua
+++ b/lua/flemma/tools/approval.lua
@@ -377,14 +377,16 @@ function M.setup()
         return nil
       end
 
-      -- Resolve effective sandbox config (global + frontmatter + runtime override)
-      local sandbox = require("flemma.sandbox")
-      local sandbox_config = sandbox.resolve_config(context.opts)
-      if not sandbox_config.enabled or sandbox_config.auto_approve == false then
+      -- Check the config-level opt-out (tools.auto_approve_sandboxed)
+      if tools_config and tools_config.auto_approve_sandboxed == false then
         return nil
       end
 
-      -- Verify a backend is actually available (not just configured)
+      -- Verify sandbox is enabled and a backend is actually available
+      local sandbox = require("flemma.sandbox")
+      if not sandbox.is_enabled(context.opts) then
+        return nil
+      end
       local backend_ok = sandbox.validate_backend(context.opts)
       if not backend_ok then
         return nil

--- a/lua/flemma/tools/definitions/bash.lua
+++ b/lua/flemma/tools/definitions/bash.lua
@@ -13,6 +13,7 @@ local truncate = require("flemma.tools.truncate")
 M.definitions = {
   {
     name = "bash",
+    capabilities = { "can_auto_approve_if_sandboxed" },
     description = "Execute a bash command in the current working directory. "
       .. "Returns stdout and stderr. Output is truncated to last "
       .. truncate.MAX_LINES

--- a/lua/flemma/tools/registry.lua
+++ b/lua/flemma/tools/registry.lua
@@ -43,6 +43,7 @@ local M = {}
 ---@field enabled? boolean Set to false to exclude from API requests by default (still executable, can be enabled via flemma.opt.tools)
 ---@field executable? boolean Set to false to disable execution
 ---@field execute? fun(input: table<string, any>, context: flemma.tools.ExecutionContext, callback?: fun(result: flemma.tools.ExecutionResult)): any Executor function (sync returns ExecutionResult, async returns cancel fn or nil)
+---@field capabilities? string[] Declarative capability tags (e.g., "can_auto_approve_if_sandboxed") queried by resolvers and policies
 ---@field format_preview? fun(input: table<string, any>, max_length: integer): string Custom preview body generator (receives input and available width after "name: " prefix)
 
 ---@class flemma.tools.ExecutionResult

--- a/tests/flemma/tool_approval_spec.lua
+++ b/tests/flemma/tool_approval_spec.lua
@@ -2321,10 +2321,9 @@ describe("Sandbox auto-approval resolver", function()
   ---@param overrides? table Overrides merged into the default config
   local function setup_with_sandbox(overrides)
     local config = vim.tbl_deep_extend("force", {
-      tools = { auto_approve = { "$default" } },
+      tools = { auto_approve = { "$default" }, auto_approve_sandboxed = true },
       sandbox = {
         enabled = true,
-        auto_approve = true,
         backend = "auto",
       },
     }, overrides or {})
@@ -2377,8 +2376,8 @@ describe("Sandbox auto-approval resolver", function()
     assert.equals("require_approval", result)
   end)
 
-  it("requires approval when sandbox.auto_approve is false", function()
-    setup_with_sandbox({ sandbox = { auto_approve = false } })
+  it("requires approval when tools.auto_approve_sandboxed is false", function()
+    setup_with_sandbox({ tools = { auto_approve_sandboxed = false } })
     local result = approval.resolve("bash", {}, { bufnr = 1, tool_id = "t1" })
     assert.equals("require_approval", result)
   end)
@@ -2389,17 +2388,6 @@ describe("Sandbox auto-approval resolver", function()
       bufnr = 1,
       tool_id = "t1",
       opts = { auto_approve_exclusions = { bash = true } },
-    }
-    local result = approval.resolve("bash", {}, ctx)
-    assert.equals("require_approval", result)
-  end)
-
-  it("respects frontmatter sandbox.auto_approve = false", function()
-    setup_with_sandbox()
-    local ctx = {
-      bufnr = 1,
-      tool_id = "t1",
-      opts = { sandbox = { auto_approve = false } },
     }
     local result = approval.resolve("bash", {}, ctx)
     assert.equals("require_approval", result)


### PR DESCRIPTION
Register a sandbox-aware approval resolver (`urn:flemma:approval:sandbox`)
at priority 25 that auto-approves tools declaring the
`can_auto_approve_if_sandboxed` capability when sandboxing is enabled
and a backend is available. Currently only the built-in `bash` tool
declares this capability. This gives users safe, frictionless tool
execution out of the box while maintaining the security boundary.

The resolver sits below config (P100), frontmatter (P90), and the
community default (P50), so explicit user preferences and third-party
resolvers always win. The resolver also requires `tools.auto_approve`
to be configured — it won't make exceptions when the user hasn't opted
into any auto-approval.

Users can opt out via:
- Config: `tools.auto_approve_sandboxed = false`
- Frontmatter: `auto_approve:remove("bash")`

### Implementation details

- Adds `capabilities?: string[]` field to `ToolDefinition` for declarative
  tool metadata. The sandbox resolver queries this via the registry instead
  of hardcoding tool names.
- Adds `tools.auto_approve_sandboxed` config key (default: `true`).
- Docs updated: `docs/tools.md` (resolver table) and `docs/sandbox.md`
  (new "Auto-approval of sandboxed tools" section).
- 16 tests covering the sandbox resolver, capabilities lookup,
  config/frontmatter guards, and priority chain behavior.

### Priority band layout

| Priority | Resolver |
| -------- | -------- |
| 100 | Config (`tools.auto_approve`) |
| 90 | Frontmatter (per-buffer) |
| 50 | Community / third-party (default) |
| 25 | Flemma internal defaults (sandbox) |
| 0 | Catch-all (`require_approval = false`) |