### PR TITLE
feat: booting indicator for async tool sources

### DIFF
--- a/.changeset/booting-indicator.md
+++ b/.changeset/booting-indicator.md
@@ -1,0 +1,5 @@
+---
+"@flemma-dev/flemma.nvim": minor
+---
+
+Add booting indicator for async tool sources: `#{booting}` lualine variable, `FlemmaBootComplete` autocmd, and ⏳ indicator in `:Flemma status`

--- a/lua/flemma/config.lua
+++ b/lua/flemma/config.lua
@@ -58,7 +58,7 @@
 ---@field enabled boolean
 
 ---@class flemma.config.Statusline
----@field format string tmux-style format string for the lualine component. Variables: #{model}, #{provider}, #{thinking}. Supports conditionals: #{?cond,true,false}
+---@field format string tmux-style format string for the lualine component. Variables: #{model}, #{provider}, #{thinking}, #{booting}. Supports conditionals: #{?cond,true,false}
 
 ---@class flemma.config.Parameters
 ---@field max_tokens? integer|string Integer token count or percentage string (e.g. "50%") of model's max_output_tokens
@@ -259,7 +259,7 @@ return {
     enabled = true, -- Whether to show pricing information in notifications
   },
   statusline = {
-    format = "#{model}#{?#{thinking}, (#{thinking}),}", -- tmux-style format string. Variables: #{model}, #{provider}, #{thinking}
+    format = "#{model}#{?#{thinking}, (#{thinking}),}#{?#{booting}, ⏳,}", -- tmux-style format string. Variables: #{model}, #{provider}, #{thinking}, #{booting}
   },
   provider = "anthropic", -- Default provider: "anthropic", "openai", or "vertex"
   model = nil, -- Will use provider-specific default if nil

--- a/lua/flemma/status.lua
+++ b/lua/flemma/status.lua
@@ -535,6 +535,9 @@ function M.format(data, verbose)
   local enabled_count = #data.tools.enabled
   local disabled_count = #data.tools.disabled
   add("Tools (" .. enabled_count .. " enabled, " .. disabled_count .. " disabled)")
+  if data.tools.booting then
+    add("  ⏳ loading async tool sources…")
+  end
   if enabled_count > 0 then
     add("  ✓ " .. format_name_list(data.tools.enabled, data.tools.frontmatter_items))
   end

--- a/lua/flemma/status.lua
+++ b/lua/flemma/status.lua
@@ -8,6 +8,7 @@ local config_manager = require("flemma.core.config.manager")
 local autopilot = require("flemma.autopilot")
 local sandbox = require("flemma.sandbox")
 local str = require("flemma.utilities.string")
+local tools_module = require("flemma.tools")
 local tools_registry = require("flemma.tools.registry")
 local tool_presets = require("flemma.tools.presets")
 local registry = require("flemma.provider.registry")
@@ -24,7 +25,7 @@ local MARKER_FRONTMATTER = "✲"
 ---@field parameters { merged: table<string, any>, frontmatter_overrides: table<string, any>|nil, resolved_max_tokens: integer|nil }
 ---@field autopilot { enabled: boolean, config_enabled: boolean, buffer_state: string, max_turns: integer, frontmatter_override: boolean|nil }
 ---@field sandbox { enabled: boolean, config_enabled: boolean, runtime_override: boolean|nil, backend: string|nil, backend_mode: string|nil, backend_available: boolean, backend_error: string|nil, policy: flemma.config.SandboxPolicy }
----@field tools { enabled: string[], disabled: string[], frontmatter_items: table<string, true>|nil }
+---@field tools { enabled: string[], disabled: string[], booting: boolean, frontmatter_items: table<string, true>|nil }
 ---@field approval { source: string|nil, approved: string[], denied: string[], pending: string[], require_approval_disabled: boolean, frontmatter_items: table<string, true>|nil }
 ---@field buffer { is_chat: boolean, bufnr: integer }
 
@@ -211,6 +212,7 @@ local function collect_tools(opts)
   return {
     enabled = enabled,
     disabled = disabled,
+    booting = not tools_module.is_ready(),
     frontmatter_items = next(frontmatter_items) and frontmatter_items or nil,
   }
 end

--- a/lua/flemma/tools/init.lua
+++ b/lua/flemma/tools/init.lua
@@ -26,13 +26,14 @@ local ready_callbacks = {}
 local active_timers = {}
 local generation = 0
 
----Fire all ready callbacks and clear the list
+---Fire all ready callbacks, clear the list, and emit the boot-complete autocmd
 local function fire_ready_callbacks()
   local callbacks = ready_callbacks
   ready_callbacks = {}
   for _, cb in ipairs(callbacks) do
     cb()
   end
+  vim.api.nvim_exec_autocmds("User", { pattern = "FlemmaBootComplete" })
 end
 
 ---Register an async tool source that resolves definitions asynchronously

--- a/lua/lualine/components/flemma.lua
+++ b/lua/lualine/components/flemma.lua
@@ -10,9 +10,6 @@ local session = require("flemma.session")
 local str = require("flemma.utilities.string")
 local tools = require("flemma.tools")
 
---- Default format: model name, with thinking level in parens when active.
-local DEFAULT_FORMAT = "#{model}#{?#{thinking}, (#{thinking}),}"
-
 -- Create a new component for displaying Flemma status
 local flemma_component = lualine_component:extend()
 
@@ -173,8 +170,7 @@ function flemma_component:update_status()
     return ""
   end
 
-  local statusline_config = config.statusline or {}
-  local fmt = statusline_config.format or DEFAULT_FORMAT
+  local fmt = config.statusline.format
 
   return format.expand(fmt, build_vars(config))
 end

--- a/lua/lualine/components/flemma.lua
+++ b/lua/lualine/components/flemma.lua
@@ -16,6 +16,21 @@ local DEFAULT_FORMAT = "#{model}#{?#{thinking}, (#{thinking}),}"
 -- Create a new component for displaying Flemma status
 local flemma_component = lualine_component:extend()
 
+---@param options table Lualine component options
+function flemma_component:init(options)
+  lualine_component.init(self, options)
+
+  vim.api.nvim_create_autocmd("User", {
+    pattern = "FlemmaBootComplete",
+    callback = function()
+      local ok, lualine = pcall(require, "lualine")
+      if ok then
+        lualine.refresh()
+      end
+    end,
+  })
+end
+
 ---Resolve the current thinking/reasoning level (unified across providers).
 ---Reads from the provider's parameter proxy which includes frontmatter overrides.
 ---@param config flemma.Config

--- a/lua/lualine/components/flemma.lua
+++ b/lua/lualine/components/flemma.lua
@@ -8,6 +8,7 @@ local registry = require("flemma.provider.registry")
 local format = require("flemma.utilities.format")
 local session = require("flemma.session")
 local str = require("flemma.utilities.string")
+local tools = require("flemma.tools")
 
 --- Default format: model name, with thinking level in parens when active.
 local DEFAULT_FORMAT = "#{model}#{?#{thinking}, (#{thinking}),}"
@@ -57,6 +58,11 @@ end
 ---@return table<string, fun(): string>
 local function make_resolvers(config)
   return {
+    -- Boot state
+    booting = function()
+      return tools.is_ready() and "" or "1"
+    end,
+
     -- Identity
     model = function()
       return config.model or ""

--- a/syntax/flemma_status.vim
+++ b/syntax/flemma_status.vim
@@ -59,6 +59,7 @@ syntax region FlemmaStatusConfigBlock start="^\(Model Info\|Config (full)\)$" en
 syntax match FlemmaStatusToolEnabled "^\s\+✓ .*$"
 syntax match FlemmaStatusToolDisabled "^\s\+✗ .*$"
 syntax match FlemmaStatusToolPending "^\s\+⋯ .*$"
+syntax match FlemmaStatusBooting "^\s\+⏳ .*$"
 
 " Highlight groups
 highlight default link FlemmaStatusTitle Title
@@ -78,5 +79,6 @@ highlight default link FlemmaStatusLegend Comment
 highlight default link FlemmaStatusToolEnabled DiagnosticOk
 highlight default link FlemmaStatusToolDisabled DiagnosticWarn
 highlight default link FlemmaStatusToolPending DiagnosticInfo
+highlight default link FlemmaStatusBooting WarningMsg
 
 let b:current_syntax = "flemma_status"

--- a/tests/flemma/lualine_spec.lua
+++ b/tests/flemma/lualine_spec.lua
@@ -54,7 +54,7 @@ describe("Lualine component", function()
     -- Act
     local status = flemma_component:update_status()
 
-    -- Assert (uses default format "#{model}#{?#{thinking}, (#{thinking}),}")
+    -- Assert (default format from config.lua)
     assert.are.equal("o3 (high)", status)
   end)
 

--- a/tests/flemma/lualine_spec.lua
+++ b/tests/flemma/lualine_spec.lua
@@ -356,6 +356,47 @@ describe("Lualine component", function()
     end)
   end)
 
+  describe("booting variable", function()
+    it("should be truthy while async tool sources are pending", function()
+      -- Arrange
+      local state = require("flemma.state")
+      local config = state.get_config()
+      config.statusline.format = "#{?#{booting},booting,ready}"
+
+      local tools = require("flemma.tools")
+      tools.clear()
+      local captured_done
+      tools.register_async(function(_register, done)
+        captured_done = done
+      end)
+
+      -- Act
+      local status_text = flemma_component:update_status()
+
+      -- Assert
+      assert.are.equal("booting", status_text)
+
+      -- Cleanup: resolve the async source
+      captured_done()
+    end)
+
+    it("should be falsy once all async tool sources resolve", function()
+      -- Arrange
+      local state = require("flemma.state")
+      local config = state.get_config()
+      config.statusline.format = "#{?#{booting},booting,ready}"
+
+      local tools = require("flemma.tools")
+      tools.clear()
+
+      -- Act (no pending async sources)
+      local status_text = flemma_component:update_status()
+
+      -- Assert
+      assert.are.equal("ready", status_text)
+    end)
+  end)
+
   describe("frontmatter overrides", function()
     local state = require("flemma.state")
 

--- a/tests/flemma/lualine_spec.lua
+++ b/tests/flemma/lualine_spec.lua
@@ -384,7 +384,11 @@ describe("Lualine component", function()
     it("should refresh lualine on FlemmaBootComplete", function()
       -- Arrange: track lualine.refresh() calls
       local refresh_called = false
-      package.loaded["lualine"] = { refresh = function() refresh_called = true end }
+      package.loaded["lualine"] = {
+        refresh = function()
+          refresh_called = true
+        end,
+      }
 
       -- Re-require component so init() picks up the mock
       package.loaded["lualine.components.flemma"] = nil

--- a/tests/flemma/lualine_spec.lua
+++ b/tests/flemma/lualine_spec.lua
@@ -7,11 +7,12 @@ describe("Lualine component", function()
 
     -- Mock lualine.component before requiring the flemma component
     package.preload["lualine.component"] = function()
-      return {
-        extend = function()
-          return {}
-        end,
-      }
+      local component = {}
+      component.init = function() end
+      component.extend = function()
+        return setmetatable({}, { __index = component })
+      end
+      return component
     end
 
     -- Invalidate caches to ensure we get fresh modules
@@ -378,6 +379,30 @@ describe("Lualine component", function()
 
       -- Cleanup: resolve the async source
       captured_done()
+    end)
+
+    it("should refresh lualine on FlemmaBootComplete", function()
+      -- Arrange: track lualine.refresh() calls
+      local refresh_called = false
+      package.loaded["lualine"] = { refresh = function() refresh_called = true end }
+
+      -- Re-require component so init() picks up the mock
+      package.loaded["lualine.components.flemma"] = nil
+      flemma_component = require("lualine.components.flemma")
+
+      -- Simulate init() being called (lualine calls this on component creation)
+      if flemma_component.init then
+        flemma_component:init({})
+      end
+
+      -- Act: emit the autocmd
+      vim.api.nvim_exec_autocmds("User", { pattern = "FlemmaBootComplete" })
+
+      -- Assert
+      assert.is_true(refresh_called)
+
+      -- Cleanup
+      package.loaded["lualine"] = nil
     end)
 
     it("should be falsy once all async tool sources resolve", function()

--- a/tests/flemma/status_spec.lua
+++ b/tests/flemma/status_spec.lua
@@ -574,6 +574,63 @@ describe("flemma.status", function()
       assert.truthy(text:find("all tools auto%-approved"), "expected catch-all message")
     end)
 
+    it("shows booting indicator when tools are still loading", function()
+      ---@type flemma.status.Data
+      local data = {
+        provider = { name = "anthropic", model = "claude-sonnet-4-5-20250929", initialized = true },
+        parameters = { merged = {} },
+        autopilot = { enabled = false, buffer_state = "idle", max_turns = 100 },
+        sandbox = {
+          enabled = false,
+          config_enabled = false,
+          backend = "bwrap",
+          backend_mode = "auto",
+          backend_available = true,
+        },
+        tools = { enabled = { "bash", "read" }, disabled = {}, booting = true },
+        approval = {
+          approved = { "read" },
+          denied = {},
+          pending = { "bash" },
+          require_approval_disabled = false,
+        },
+        buffer = { is_chat = false, bufnr = 0 },
+      }
+
+      local lines = status.format(data, false)
+      local text = table.concat(lines, "\n")
+      assert.truthy(text:find("⏳"), "expected booting indicator")
+      assert.truthy(text:find("loading async tool sources"), "expected booting message")
+    end)
+
+    it("omits booting indicator when tools are ready", function()
+      ---@type flemma.status.Data
+      local data = {
+        provider = { name = "anthropic", model = "claude-sonnet-4-5-20250929", initialized = true },
+        parameters = { merged = {} },
+        autopilot = { enabled = false, buffer_state = "idle", max_turns = 100 },
+        sandbox = {
+          enabled = false,
+          config_enabled = false,
+          backend = "bwrap",
+          backend_mode = "auto",
+          backend_available = true,
+        },
+        tools = { enabled = { "bash", "read" }, disabled = {}, booting = false },
+        approval = {
+          approved = { "read" },
+          denied = {},
+          pending = { "bash" },
+          require_approval_disabled = false,
+        },
+        buffer = { is_chat = false, bufnr = 0 },
+      }
+
+      local lines = status.format(data, false)
+      local text = table.concat(lines, "\n")
+      assert.falsy(text:find("⏳"), "expected no booting indicator")
+    end)
+
     it("shows denied tools in approval digest", function()
       ---@type flemma.status.Data
       local data = {

--- a/tests/flemma/status_spec.lua
+++ b/tests/flemma/status_spec.lua
@@ -105,6 +105,44 @@ describe("flemma.status", function()
       assert.is_false(data.buffer.is_chat)
     end)
 
+    it("includes booting state when async tool sources are pending", function()
+      local state = require("flemma.state")
+      ---@diagnostic disable-next-line: missing-fields
+      state.set_config({
+        provider = "anthropic",
+        parameters = {},
+        tools = { autopilot = { enabled = false, max_turns = 100 } },
+        sandbox = { enabled = false, backend = "auto" },
+      })
+
+      local tools = require("flemma.tools")
+      tools.clear()
+      local captured_done
+      tools.register_async(function(_register, done)
+        captured_done = done
+      end)
+
+      local data = status.collect(0)
+      assert.is_true(data.tools.booting)
+
+      -- Cleanup
+      captured_done()
+    end)
+
+    it("reports booting as false when all tool sources are ready", function()
+      local state = require("flemma.state")
+      ---@diagnostic disable-next-line: missing-fields
+      state.set_config({
+        provider = "anthropic",
+        parameters = {},
+        tools = { autopilot = { enabled = false, max_turns = 100 } },
+        sandbox = { enabled = false, backend = "auto" },
+      })
+
+      local data = status.collect(0)
+      assert.is_false(data.tools.booting)
+    end)
+
     it("reports autopilot state", function()
       local state = require("flemma.state")
       ---@diagnostic disable-next-line: missing-fields

--- a/tests/flemma/status_spec.lua
+++ b/tests/flemma/status_spec.lua
@@ -586,6 +586,7 @@ describe("flemma.status", function()
           backend = "bwrap",
           backend_mode = "auto",
           backend_available = true,
+          policy = { rw_paths = {}, network = true, allow_privileged = false },
         },
         tools = { enabled = { "bash", "read" }, disabled = {}, booting = true },
         approval = {
@@ -615,6 +616,7 @@ describe("flemma.status", function()
           backend = "bwrap",
           backend_mode = "auto",
           backend_available = true,
+          policy = { rw_paths = {}, network = true, allow_privileged = false },
         },
         tools = { enabled = { "bash", "read" }, disabled = {}, booting = false },
         approval = {

--- a/tests/flemma/tool_async_spec.lua
+++ b/tests/flemma/tool_async_spec.lua
@@ -105,6 +105,28 @@ describe("Async tool sources", function()
   end)
 
   describe("on_ready()", function()
+    it("emits FlemmaBootComplete autocmd when all sources resolve", function()
+      local fired = false
+      vim.api.nvim_create_autocmd("User", {
+        pattern = "FlemmaBootComplete",
+        once = true,
+        callback = function()
+          fired = true
+        end,
+      })
+
+      local captured_done
+      tools.register_async(function(_register, done)
+        captured_done = done
+      end)
+
+      captured_done()
+      vim.wait(100, function()
+        return fired
+      end)
+      assert.is_true(fired)
+    end)
+
     it("fires immediately when already ready", function()
       local called = false
       tools.on_ready(function()


### PR DESCRIPTION
## Summary

When Flemma loads async tool sources (e.g. MCP servers, user-provided resolve functions), there's currently no way for users to know that tools are still loading. This PR adds visibility into the boot process through three surfaces:

- **Lualine `#{booting}` variable** — a new resolver that returns truthy while async tool sources are pending, allowing users to show a loading indicator in their statusline format string (e.g. `#{?#{booting},⏳ ,}#{model}`)
- **`:Flemma status` booting line** — a `⏳ loading async tool sources…` line appears in the Tools section while sources are still resolving
- **`FlemmaBootComplete` autocmd** — a `User` autocmd that fires once all async tool sources have resolved, enabling downstream integrations (the lualine component uses this to auto-refresh)

## Architecture

No new modules. This extends three existing files plus the syntax file:

### `lua/flemma/tools/init.lua`
`fire_ready_callbacks()` now emits `vim.api.nvim_exec_autocmds("User", { pattern = "FlemmaBootComplete" })` after draining the callback queue. This is the single event that signals boot completion.

### `lua/lualine/components/flemma.lua`
- New `booting` resolver in `make_resolvers()`: returns `"1"` while `tools.is_ready()` is false, `""` when ready. This integrates with the existing conditional format system (`#{?#{booting},true_branch,false_branch}`).
- New `init()` override: creates a `User FlemmaBootComplete` autocmd that calls `lualine.refresh()`, so the statusline updates automatically when boot finishes (no polling needed).

### `lua/flemma/status.lua`
- `collect_tools()` now includes `booting = not tools_module.is_ready()` in its return table.
- `format()` conditionally inserts `  ⏳ loading async tool sources…` after the Tools header when `data.tools.booting` is true.
- The `flemma.status.Data` type annotation is updated to include `booting: boolean` on the tools field.

### `syntax/flemma_status.vim`
- New `FlemmaStatusBooting` match for `^\s\+⏳ .*$`, linked to `WarningMsg` highlight group.

## Testing

All changes are TDD — tests were written first, verified to fail, then implementation was added:

- **`tests/flemma/tool_async_spec.lua`** — 1 new test: verifies `FlemmaBootComplete` autocmd fires when the last async source resolves
- **`tests/flemma/lualine_spec.lua`** — 3 new tests: `#{booting}` truthy while pending, falsy when ready, and lualine refresh on `FlemmaBootComplete`. The lualine mock was also improved to support proper `init()` inheritance (added `init` method and `setmetatable`-based `extend`)
- **`tests/flemma/status_spec.lua`** — 4 new tests: `data.tools.booting` true/false in `collect()`, and `⏳` presence/absence in `format()`

## Test plan

- [ ] `make qa` passes (verified: `qa: OK`)
- [ ] New lualine variable works in a format string: `#{?#{booting},⏳ loading…,}#{model}`
- [ ] `:Flemma status` shows `⏳ loading async tool sources…` while a slow async source is pending
- [ ] `:Flemma status` omits the booting line once all sources resolve
- [ ] Lualine auto-refreshes when boot completes (no manual refresh needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>