### PR TITLE
feat(config): unified configuration system with layered CoW store

### DIFF
--- a/.changeset/config-schema-node-types.md
+++ b/.changeset/config-schema-node-types.md
@@ -1,5 +1,0 @@
----
-"@flemma-dev/flemma.nvim": minor
----
-
-Implement schema node types (`flemma.config.schema.types`) with validation and materialization — the foundation of the unified config system. Provides `StringNode`, `IntegerNode`, `NumberNode`, `BooleanNode`, `EnumNode`, `ObjectNode`, `ListNode`, `MapNode`, `OptionalNode`, `UnionNode`, `FuncNode`, and `LoadableNode`, all supporting method chaining for metadata decoration.

--- a/.changeset/config-schema-node-types.md
+++ b/.changeset/config-schema-node-types.md
@@ -1,0 +1,5 @@
+---
+"@flemma-dev/flemma.nvim": minor
+---
+
+Implement schema node types (`flemma.config.schema.types`) with validation and materialization — the foundation of the unified config system. Provides `StringNode`, `IntegerNode`, `NumberNode`, `BooleanNode`, `EnumNode`, `ObjectNode`, `ListNode`, `MapNode`, `OptionalNode`, `UnionNode`, `FuncNode`, and `LoadableNode`, all supporting method chaining for metadata decoration.

--- a/lua/flemma/config/schema/init.lua
+++ b/lua/flemma/config/schema/init.lua
@@ -1,0 +1,97 @@
+--- Schema DSL factory — thin wrapper providing the user-facing API for schema node creation.
+---
+--- This module is a factory for creating schema nodes defined in `flemma.config.schema.types`.
+--- It provides a clean DSL interface: `s.string()`, `s.object()`, etc.
+---
+---@class flemma.config.schema
+local M = {}
+
+local types = require("flemma.config.schema.types")
+
+--- Create a StringNode with an optional default value.
+---@param default string|nil
+---@return flemma.config.schema.StringNode
+function M.string(default)
+  return types.StringNode.new(default)
+end
+
+--- Create an IntegerNode with an optional default value.
+---@param default integer|nil
+---@return flemma.config.schema.IntegerNode
+function M.integer(default)
+  return types.IntegerNode.new(default)
+end
+
+--- Create a NumberNode with an optional default value.
+---@param default number|nil
+---@return flemma.config.schema.NumberNode
+function M.number(default)
+  return types.NumberNode.new(default)
+end
+
+--- Create a BooleanNode with an optional default value.
+---@param default boolean|nil
+---@return flemma.config.schema.BooleanNode
+function M.boolean(default)
+  return types.BooleanNode.new(default)
+end
+
+--- Create an EnumNode from a list of valid values and an optional default.
+---@param values string[] Array of valid enum values
+---@param default string|nil
+---@return flemma.config.schema.EnumNode
+function M.enum(values, default)
+  return types.EnumNode.new(values, default)
+end
+
+--- Create a ListNode with an item schema and optional default list.
+---@param item_schema flemma.config.schema.Node Schema applied to each list item
+---@param default table|nil Default list value
+---@return flemma.config.schema.ListNode
+function M.list(item_schema, default)
+  return types.ListNode.new(item_schema, default)
+end
+
+--- Create a MapNode with key and value schemas.
+---@param key_schema flemma.config.schema.Node Schema applied to each key
+---@param value_schema flemma.config.schema.Node Schema applied to each value
+---@return flemma.config.schema.MapNode
+function M.map(key_schema, value_schema)
+  return types.MapNode.new(key_schema, value_schema)
+end
+
+--- Create an ObjectNode from a fields table containing string-keyed child schemas.
+---@param fields table String-keyed table of child schemas
+---@return flemma.config.schema.ObjectNode
+function M.object(fields)
+  return types.ObjectNode.new(fields)
+end
+
+--- Create an OptionalNode wrapping an inner schema.
+---@param inner flemma.config.schema.Node The inner schema to wrap
+---@return flemma.config.schema.OptionalNode
+function M.optional(inner)
+  return types.OptionalNode.new(inner)
+end
+
+--- Create a UnionNode from variadic branch schemas.
+---@param ... flemma.config.schema.Node One or more branch schemas
+---@return flemma.config.schema.UnionNode
+function M.union(...)
+  local branches = { ... }
+  return types.UnionNode.new(branches)
+end
+
+--- Create a FuncNode for function-type values.
+---@return flemma.config.schema.FuncNode
+function M.func()
+  return types.FuncNode.new()
+end
+
+--- Create a LoadableNode for Lua module path strings.
+---@return flemma.config.schema.LoadableNode
+function M.loadable()
+  return types.LoadableNode.new()
+end
+
+return M

--- a/lua/flemma/config/schema/types.lua
+++ b/lua/flemma/config/schema/types.lua
@@ -6,6 +6,7 @@
 ---@class flemma.config.schema.types
 local M = {}
 
+local loader = require("flemma.loader")
 local symbols = require("flemma.symbols")
 
 -- =============================================================================
@@ -392,6 +393,20 @@ function MapNode:validate(value)
   return type(value) == "table"
 end
 
+--- Validate a single map key against the key schema.
+---@param key any
+---@return boolean
+function MapNode:validate_key(key)
+  return self._key_schema:validate(key)
+end
+
+--- Validate a single map value against the value schema.
+---@param value any
+---@return boolean
+function MapNode:validate_value(value)
+  return self._value_schema:validate(value)
+end
+
 M.MapNode = MapNode
 
 -- =============================================================================
@@ -417,6 +432,13 @@ end
 ---@return any
 function OptionalNode:materialize()
   return self._inner:materialize()
+end
+
+--- Delegate is_list() to the inner schema so that optional list fields are
+--- correctly identified as lists by the proxy/store layer.
+---@return boolean
+function OptionalNode:is_list()
+  return self._inner:is_list()
 end
 
 --- Return true for nil (not present) or any value valid under the inner schema.
@@ -521,15 +543,16 @@ function LoadableNode:materialize()
   return nil
 end
 
---- Return true if value is a string containing at least one dot
---- (Lua module path convention). Flemma URNs are not loadable module paths.
+--- Return true if value is a string that looks like a valid Lua module path.
+--- Delegates to flemma.loader.is_module_path() which handles the dot-notation
+--- check and correctly rejects Flemma URNs (urn:flemma:...).
 ---@param value any
 ---@return boolean
 function LoadableNode:validate(value)
   if type(value) ~= "string" then
     return false
   end
-  return value:find(".", 1, true) ~= nil
+  return loader.is_module_path(value)
 end
 
 M.LoadableNode = LoadableNode

--- a/lua/flemma/config/schema/types.lua
+++ b/lua/flemma/config/schema/types.lua
@@ -1,0 +1,537 @@
+--- Schema node type definitions for Flemma's unified config system
+---
+--- Each node type knows how to materialize its default value and validate
+--- incoming values. Nodes support method chaining for metadata decoration.
+---
+---@class flemma.config.schema.types
+local M = {}
+
+local symbols = require("flemma.symbols")
+
+-- =============================================================================
+-- Base node (shared behaviour)
+-- =============================================================================
+
+---@class flemma.config.schema.Node
+---@field _description string|nil Human-readable description for EmmyLua generation
+---@field _type_as string|nil Type annotation override for EmmyLua generation
+---@field _strict boolean Whether the node is in strict mode (ObjectNode default)
+---@field materialize fun(self: flemma.config.schema.Node): any Return the default value for this node
+---@field validate fun(self: flemma.config.schema.Node, value: any): boolean Return true if value is valid for this node
+local BaseNode = {}
+BaseNode.__index = BaseNode
+
+--- Store a human-readable description. Returns self for chaining.
+---@param text string
+---@return flemma.config.schema.Node
+function BaseNode:describe(text)
+  self._description = text
+  return self
+end
+
+--- Override the generated EmmyLua type annotation. Returns self for chaining.
+---@param text string
+---@return flemma.config.schema.Node
+function BaseNode:type_as(text)
+  self._type_as = text
+  return self
+end
+
+--- Enable strict validation mode. Returns self for chaining.
+---@return flemma.config.schema.Node
+function BaseNode:strict()
+  self._strict = true
+  return self
+end
+
+--- Disable strict validation mode (allow unknown keys). Returns self for chaining.
+---@return flemma.config.schema.Node
+function BaseNode:passthrough()
+  self._strict = false
+  return self
+end
+
+--- Returns whether this node represents an ordered list. Default is false.
+---@return boolean
+function BaseNode:is_list()
+  return false
+end
+
+-- =============================================================================
+-- StringNode
+-- =============================================================================
+
+---@class flemma.config.schema.StringNode : flemma.config.schema.Node
+---@field _default string|nil
+local StringNode = setmetatable({}, { __index = BaseNode })
+StringNode.__index = StringNode
+
+--- Create a new StringNode with an optional default value.
+---@param default string|nil
+---@return flemma.config.schema.StringNode
+function StringNode.new(default)
+  local self = setmetatable({}, StringNode)
+  self._default = default
+  return self
+end
+
+--- Return the default string value.
+---@return string|nil
+function StringNode:materialize()
+  return self._default
+end
+
+--- Return true if value is a string.
+---@param value any
+---@return boolean
+function StringNode:validate(value)
+  return type(value) == "string"
+end
+
+M.StringNode = StringNode
+
+-- =============================================================================
+-- IntegerNode
+-- =============================================================================
+
+---@class flemma.config.schema.IntegerNode : flemma.config.schema.Node
+---@field _default integer|nil
+local IntegerNode = setmetatable({}, { __index = BaseNode })
+IntegerNode.__index = IntegerNode
+
+--- Create a new IntegerNode with an optional default value.
+---@param default integer|nil
+---@return flemma.config.schema.IntegerNode
+function IntegerNode.new(default)
+  local self = setmetatable({}, IntegerNode)
+  self._default = default
+  return self
+end
+
+--- Return the default integer value.
+---@return integer|nil
+function IntegerNode:materialize()
+  return self._default
+end
+
+--- Return true if value is a number with no fractional part.
+--- In LuaJIT all numbers are doubles; we check type == "number" and no fraction.
+---@param value any
+---@return boolean
+function IntegerNode:validate(value)
+  if type(value) ~= "number" then
+    return false
+  end
+  return math.floor(value) == value
+end
+
+M.IntegerNode = IntegerNode
+
+-- =============================================================================
+-- NumberNode
+-- =============================================================================
+
+---@class flemma.config.schema.NumberNode : flemma.config.schema.Node
+---@field _default number|nil
+local NumberNode = setmetatable({}, { __index = BaseNode })
+NumberNode.__index = NumberNode
+
+--- Create a new NumberNode with an optional default value.
+---@param default number|nil
+---@return flemma.config.schema.NumberNode
+function NumberNode.new(default)
+  local self = setmetatable({}, NumberNode)
+  self._default = default
+  return self
+end
+
+--- Return the default number value.
+---@return number|nil
+function NumberNode:materialize()
+  return self._default
+end
+
+--- Return true if value is a number.
+---@param value any
+---@return boolean
+function NumberNode:validate(value)
+  return type(value) == "number"
+end
+
+M.NumberNode = NumberNode
+
+-- =============================================================================
+-- BooleanNode
+-- =============================================================================
+
+---@class flemma.config.schema.BooleanNode : flemma.config.schema.Node
+---@field _default boolean|nil
+local BooleanNode = setmetatable({}, { __index = BaseNode })
+BooleanNode.__index = BooleanNode
+
+--- Create a new BooleanNode with an optional default value.
+---@param default boolean|nil
+---@return flemma.config.schema.BooleanNode
+function BooleanNode.new(default)
+  local self = setmetatable({}, BooleanNode)
+  self._default = default
+  return self
+end
+
+--- Return the default boolean value.
+---@return boolean|nil
+function BooleanNode:materialize()
+  return self._default
+end
+
+--- Return true if value is a boolean.
+---@param value any
+---@return boolean
+function BooleanNode:validate(value)
+  return type(value) == "boolean"
+end
+
+M.BooleanNode = BooleanNode
+
+-- =============================================================================
+-- EnumNode
+-- =============================================================================
+
+---@class flemma.config.schema.EnumNode : flemma.config.schema.Node
+---@field _default string|nil
+---@field _values_set table<string, boolean> Lookup table for valid values
+local EnumNode = setmetatable({}, { __index = BaseNode })
+EnumNode.__index = EnumNode
+
+--- Create a new EnumNode from an array of valid values and an optional default.
+---@param values string[] Array of valid enum values
+---@param default string|nil
+---@return flemma.config.schema.EnumNode
+function EnumNode.new(values, default)
+  local self = setmetatable({}, EnumNode)
+  self._default = default
+  self._values_set = {}
+  for _, v in ipairs(values) do
+    self._values_set[v] = true
+  end
+  return self
+end
+
+--- Return the default enum value.
+---@return string|nil
+function EnumNode:materialize()
+  return self._default
+end
+
+--- Return true if value is one of the valid enum values.
+---@param value any
+---@return boolean
+function EnumNode:validate(value)
+  if type(value) ~= "string" then
+    return false
+  end
+  return self._values_set[value] == true
+end
+
+M.EnumNode = EnumNode
+
+-- =============================================================================
+-- ObjectNode
+-- =============================================================================
+
+---@class flemma.config.schema.ObjectNode : flemma.config.schema.Node
+---@field _fields table<string, flemma.config.schema.Node> String-keyed child schemas
+---@field _aliases table<string, string>|nil Alias map extracted from symbols.ALIASES
+---@field _discover (fun(key: string): flemma.config.schema.Node|nil)|nil Lazy resolution callback
+local ObjectNode = setmetatable({}, { __index = BaseNode })
+ObjectNode.__index = ObjectNode
+
+--- Create a new ObjectNode from a fields table.
+---
+--- Symbol keys (symbols.ALIASES, symbols.DISCOVER) are extracted from the
+--- fields table into dedicated fields on the node; they are not included in
+--- _fields and will not appear in materialized output.
+---
+---@param fields table Raw fields table, may contain symbol keys
+---@return flemma.config.schema.ObjectNode
+function ObjectNode.new(fields)
+  local self = setmetatable({}, ObjectNode)
+  self._strict = true
+  self._fields = {}
+  self._aliases = nil
+  self._discover = nil
+
+  for key, value in pairs(fields) do
+    if key == symbols.ALIASES then
+      self._aliases = value
+    elseif key == symbols.DISCOVER then
+      self._discover = value
+    elseif type(key) == "string" then
+      self._fields[key] = value
+    end
+  end
+
+  return self
+end
+
+--- Recursively materialize all child field defaults into a new table.
+--- Uses vim.deepcopy for value independence when schema nodes are reused.
+---@return table
+function ObjectNode:materialize()
+  local result = {}
+  for field_name, field_schema in pairs(self._fields) do
+    local materialized = field_schema:materialize()
+    if materialized ~= nil then
+      result[field_name] = vim.deepcopy(materialized)
+    end
+  end
+  return result
+end
+
+--- Return true if value is a table.
+---@param value any
+---@return boolean
+function ObjectNode:validate(value)
+  return type(value) == "table"
+end
+
+--- Resolve a shorthand alias key to its canonical path string.
+--- Returns nil if no alias is registered for the given key.
+--- Aliases do not chain — only one level of resolution is performed.
+---@param key string
+---@return string|nil
+function ObjectNode:resolve_alias(key)
+  if not self._aliases then
+    return nil
+  end
+  return self._aliases[key]
+end
+
+M.ObjectNode = ObjectNode
+
+-- =============================================================================
+-- ListNode
+-- =============================================================================
+
+---@class flemma.config.schema.ListNode : flemma.config.schema.Node
+---@field _item_schema flemma.config.schema.Node Schema for each list item
+---@field _default table Default list value (deep copied on materialize)
+local ListNode = setmetatable({}, { __index = BaseNode })
+ListNode.__index = ListNode
+
+--- Create a new ListNode with an item schema and optional default list.
+---@param item_schema flemma.config.schema.Node Schema applied to each item
+---@param default table|nil Default list; defaults to empty table if omitted
+---@return flemma.config.schema.ListNode
+function ListNode.new(item_schema, default)
+  local self = setmetatable({}, ListNode)
+  self._item_schema = item_schema
+  self._default = default or {}
+  return self
+end
+
+--- Return a deep copy of the default list.
+---@return table
+function ListNode:materialize()
+  return vim.deepcopy(self._default)
+end
+
+--- Return true for all list nodes.
+---@return boolean
+function ListNode:is_list()
+  return true
+end
+
+--- Return true if value is a table (list).
+---@param value any
+---@return boolean
+function ListNode:validate(value)
+  return type(value) == "table"
+end
+
+--- Validate a single item against the item schema.
+---@param value any
+---@return boolean
+function ListNode:validate_item(value)
+  return self._item_schema:validate(value)
+end
+
+M.ListNode = ListNode
+
+-- =============================================================================
+-- MapNode
+-- =============================================================================
+
+---@class flemma.config.schema.MapNode : flemma.config.schema.Node
+---@field _key_schema flemma.config.schema.Node Schema for map keys
+---@field _value_schema flemma.config.schema.Node Schema for map values
+local MapNode = setmetatable({}, { __index = BaseNode })
+MapNode.__index = MapNode
+
+--- Create a new MapNode with key and value schemas.
+---@param key_schema flemma.config.schema.Node Schema applied to each key
+---@param value_schema flemma.config.schema.Node Schema applied to each value
+---@return flemma.config.schema.MapNode
+function MapNode.new(key_schema, value_schema)
+  local self = setmetatable({}, MapNode)
+  self._key_schema = key_schema
+  self._value_schema = value_schema
+  return self
+end
+
+--- Return an empty table as the default map.
+---@return table
+function MapNode:materialize()
+  return {}
+end
+
+--- Return true if value is a table.
+---@param value any
+---@return boolean
+function MapNode:validate(value)
+  return type(value) == "table"
+end
+
+M.MapNode = MapNode
+
+-- =============================================================================
+-- OptionalNode
+-- =============================================================================
+
+---@class flemma.config.schema.OptionalNode : flemma.config.schema.Node
+---@field _inner flemma.config.schema.Node The wrapped inner schema
+local OptionalNode = setmetatable({}, { __index = BaseNode })
+OptionalNode.__index = OptionalNode
+
+--- Create a new OptionalNode wrapping an inner schema.
+---@param inner_schema flemma.config.schema.Node
+---@return flemma.config.schema.OptionalNode
+function OptionalNode.new(inner_schema)
+  local self = setmetatable({}, OptionalNode)
+  self._inner = inner_schema
+  return self
+end
+
+--- Delegate materialization to the inner schema.
+--- Returns nil if the inner schema has no default.
+---@return any
+function OptionalNode:materialize()
+  return self._inner:materialize()
+end
+
+--- Return true for nil (not present) or any value valid under the inner schema.
+---@param value any
+---@return boolean
+function OptionalNode:validate(value)
+  if value == nil then
+    return true
+  end
+  return self._inner:validate(value)
+end
+
+M.OptionalNode = OptionalNode
+
+-- =============================================================================
+-- UnionNode
+-- =============================================================================
+
+---@class flemma.config.schema.UnionNode : flemma.config.schema.Node
+---@field _branches flemma.config.schema.Node[] Ordered array of branch schemas
+local UnionNode = setmetatable({}, { __index = BaseNode })
+UnionNode.__index = UnionNode
+
+--- Create a new UnionNode from an array of branch schemas.
+---@param branches flemma.config.schema.Node[]
+---@return flemma.config.schema.UnionNode
+function UnionNode.new(branches)
+  local self = setmetatable({}, UnionNode)
+  self._branches = branches
+  return self
+end
+
+--- Return the default from the first branch.
+---@return any
+function UnionNode:materialize()
+  if #self._branches > 0 then
+    return self._branches[1]:materialize()
+  end
+  return nil
+end
+
+--- Return true if value matches any branch schema.
+---@param value any
+---@return boolean
+function UnionNode:validate(value)
+  for _, branch in ipairs(self._branches) do
+    if branch:validate(value) then
+      return true
+    end
+  end
+  return false
+end
+
+M.UnionNode = UnionNode
+
+-- =============================================================================
+-- FuncNode
+-- =============================================================================
+
+---@class flemma.config.schema.FuncNode : flemma.config.schema.Node
+local FuncNode = setmetatable({}, { __index = BaseNode })
+FuncNode.__index = FuncNode
+
+--- Create a new FuncNode.
+---@return flemma.config.schema.FuncNode
+function FuncNode.new()
+  return setmetatable({}, FuncNode)
+end
+
+--- Return nil (functions have no meaningful default).
+---@return nil
+function FuncNode:materialize()
+  return nil
+end
+
+--- Return true if value is a function.
+---@param value any
+---@return boolean
+function FuncNode:validate(value)
+  return type(value) == "function"
+end
+
+M.FuncNode = FuncNode
+
+-- =============================================================================
+-- LoadableNode
+-- =============================================================================
+
+---@class flemma.config.schema.LoadableNode : flemma.config.schema.Node
+local LoadableNode = setmetatable({}, { __index = BaseNode })
+LoadableNode.__index = LoadableNode
+
+--- Create a new LoadableNode.
+---@return flemma.config.schema.LoadableNode
+function LoadableNode.new()
+  return setmetatable({}, LoadableNode)
+end
+
+--- Return nil (loadable paths have no meaningful default).
+---@return nil
+function LoadableNode:materialize()
+  return nil
+end
+
+--- Return true if value is a string containing at least one dot
+--- (Lua module path convention). Flemma URNs are not loadable module paths.
+---@param value any
+---@return boolean
+function LoadableNode:validate(value)
+  if type(value) ~= "string" then
+    return false
+  end
+  return value:find(".", 1, true) ~= nil
+end
+
+M.LoadableNode = LoadableNode
+
+return M

--- a/lua/flemma/symbols.lua
+++ b/lua/flemma/symbols.lua
@@ -60,6 +60,19 @@ M.INCLUDE_BINARY = {}
 ---@type table
 M.INCLUDE_MIME = {}
 
+--- Schema alias definitions.
+--- Used as a key on schema object nodes to define shorthand paths that
+--- redirect reads and writes to canonical locations.
+---@type table
+M.ALIASES = {}
+
+--- Schema discovery callback.
+--- Used as a key on schema object nodes to provide lazy schema resolution
+--- for dynamically registered modules (providers, tools). The callback
+--- receives an unknown key and returns a schema node or nil.
+---@type table
+M.DISCOVER = {}
+
 --- Deep-copy a table while preserving symbol key identity.
 ---
 --- vim.deepcopy copies table *keys* by value, creating new table references

--- a/tests/flemma/config/schema_spec.lua
+++ b/tests/flemma/config/schema_spec.lua
@@ -391,6 +391,20 @@ describe("flemma.config.schema.types", function()
     it(":is_list() returns false", function()
       assert.is_false(types.MapNode.new(types.StringNode.new(), types.StringNode.new()):is_list())
     end)
+
+    it("validate_key() delegates to the key schema", function()
+      local node = types.MapNode.new(types.StringNode.new(), types.IntegerNode.new())
+      assert.is_true(node:validate_key("valid_key"))
+      assert.is_false(node:validate_key(42))
+      assert.is_false(node:validate_key({}))
+    end)
+
+    it("validate_value() delegates to the value schema", function()
+      local node = types.MapNode.new(types.StringNode.new(), types.IntegerNode.new())
+      assert.is_true(node:validate_value(10))
+      assert.is_false(node:validate_value("not an integer"))
+      assert.is_false(node:validate_value({}))
+    end)
   end)
 
   -- =========================================================================
@@ -423,8 +437,13 @@ describe("flemma.config.schema.types", function()
       assert.is_nil(node:materialize())
     end)
 
-    it(":is_list() returns false", function()
+    it(":is_list() returns false when wrapping a non-list schema", function()
       assert.is_false(types.OptionalNode.new(types.StringNode.new()):is_list())
+    end)
+
+    it(":is_list() delegates to inner schema", function()
+      local node = types.OptionalNode.new(types.ListNode.new(types.StringNode.new()))
+      assert.is_true(node:is_list())
     end)
 
     it(":describe() and :type_as() chain correctly", function()
@@ -508,6 +527,11 @@ describe("flemma.config.schema.types", function()
       assert.is_false(node:validate("nodots"))
       assert.is_false(node:validate(""))
       assert.is_false(node:validate(42))
+    end)
+
+    it("validate() returns false for Flemma URNs even when they contain dots", function()
+      local node = types.LoadableNode.new()
+      assert.is_false(node:validate("urn:flemma:some.dotted.segment"))
     end)
 
     it("validate() returns false for non-string values", function()

--- a/tests/flemma/config/schema_spec.lua
+++ b/tests/flemma/config/schema_spec.lua
@@ -1,0 +1,559 @@
+local symbols = require("flemma.symbols")
+
+describe("flemma.config.schema.types", function()
+  local types
+
+  before_each(function()
+    package.loaded["flemma.config.schema.types"] = nil
+    types = require("flemma.config.schema.types")
+  end)
+
+  -- =========================================================================
+  -- Scalar nodes
+  -- =========================================================================
+
+  describe("StringNode", function()
+    it("materialize() returns the default value", function()
+      local node = types.StringNode.new("hello")
+      assert.are.equal("hello", node:materialize())
+    end)
+
+    it("materialize() returns nil when no default is provided", function()
+      local node = types.StringNode.new()
+      assert.is_nil(node:materialize())
+    end)
+
+    it("validate() returns true for a string value", function()
+      local node = types.StringNode.new("default")
+      assert.is_true(node:validate("any string"))
+    end)
+
+    it("validate() returns false for a non-string value", function()
+      local node = types.StringNode.new("default")
+      assert.is_false(node:validate(42))
+      assert.is_false(node:validate(true))
+      assert.is_false(node:validate({}))
+    end)
+
+    it(":describe() stores description and returns self", function()
+      local node = types.StringNode.new("x")
+      local returned = node:describe("my description")
+      assert.are.equal(node, returned)
+      assert.are.equal("my description", node._description)
+    end)
+
+    it(":type_as() stores type override and returns self", function()
+      local node = types.StringNode.new("x")
+      local returned = node:type_as("string|nil")
+      assert.are.equal(node, returned)
+      assert.are.equal("string|nil", node._type_as)
+    end)
+  end)
+
+  describe("IntegerNode", function()
+    it("materialize() returns the default integer", function()
+      local node = types.IntegerNode.new(8192)
+      assert.are.equal(8192, node:materialize())
+    end)
+
+    it("validate() returns true for an integer value", function()
+      local node = types.IntegerNode.new(0)
+      assert.is_true(node:validate(42))
+      assert.is_true(node:validate(0))
+      assert.is_true(node:validate(-10))
+    end)
+
+    it("validate() returns false for non-integer values", function()
+      local node = types.IntegerNode.new(0)
+      assert.is_false(node:validate(3.14))
+      assert.is_false(node:validate("42"))
+      assert.is_false(node:validate(true))
+    end)
+
+    it("validate() returns false for floats even when they have integer values", function()
+      -- 5.0 is a number/float, not an integer in Lua type sense
+      -- We check math.type == "integer" for strict integer validation
+      local node = types.IntegerNode.new(0)
+      -- In LuaJIT (which Neovim uses), all numbers are doubles, so we just check type == "number"
+      -- and math.floor(v) == v for integer validation
+      assert.is_false(node:validate(3.5))
+    end)
+
+    it(":describe() and :type_as() chain correctly", function()
+      local node = types.IntegerNode.new(1)
+      local result = node:describe("desc"):type_as("integer")
+      assert.are.equal(node, result)
+    end)
+  end)
+
+  describe("NumberNode", function()
+    it("materialize() returns the default number", function()
+      local node = types.NumberNode.new(0.7)
+      assert.are.equal(0.7, node:materialize())
+    end)
+
+    it("validate() returns true for number values", function()
+      local node = types.NumberNode.new(0)
+      assert.is_true(node:validate(3.14))
+      assert.is_true(node:validate(0))
+      assert.is_true(node:validate(-1.5))
+      assert.is_true(node:validate(42))
+    end)
+
+    it("validate() returns false for non-number values", function()
+      local node = types.NumberNode.new(0)
+      assert.is_false(node:validate("1.0"))
+      assert.is_false(node:validate(true))
+      assert.is_false(node:validate({}))
+    end)
+  end)
+
+  describe("BooleanNode", function()
+    it("materialize() returns the default boolean", function()
+      local node = types.BooleanNode.new(true)
+      assert.is_true(node:materialize())
+      local node2 = types.BooleanNode.new(false)
+      assert.is_false(node2:materialize())
+    end)
+
+    it("validate() returns true for boolean values", function()
+      local node = types.BooleanNode.new(false)
+      assert.is_true(node:validate(true))
+      assert.is_true(node:validate(false))
+    end)
+
+    it("validate() returns false for non-boolean values", function()
+      local node = types.BooleanNode.new(false)
+      assert.is_false(node:validate(1))
+      assert.is_false(node:validate("true"))
+      assert.is_false(node:validate(nil))
+    end)
+  end)
+
+  describe("EnumNode", function()
+    it("materialize() returns the default enum value", function()
+      local node = types.EnumNode.new({ "disabled", "low", "medium", "high" }, "medium")
+      assert.are.equal("medium", node:materialize())
+    end)
+
+    it("validate() returns true for values in the set", function()
+      local node = types.EnumNode.new({ "a", "b", "c" }, "a")
+      assert.is_true(node:validate("a"))
+      assert.is_true(node:validate("b"))
+      assert.is_true(node:validate("c"))
+    end)
+
+    it("validate() returns false for values not in the set", function()
+      local node = types.EnumNode.new({ "a", "b", "c" }, "a")
+      assert.is_false(node:validate("d"))
+      assert.is_false(node:validate(""))
+      assert.is_false(node:validate(1))
+    end)
+
+    it(":describe() and :type_as() return self for chaining", function()
+      local node = types.EnumNode.new({ "x", "y" }, "x")
+      assert.are.equal(node, node:describe("test"))
+      assert.are.equal(node, node:type_as("string"))
+    end)
+  end)
+
+  -- =========================================================================
+  -- Base node shared methods
+  -- =========================================================================
+
+  describe("base node methods", function()
+    it(":strict() returns self", function()
+      local node = types.StringNode.new("x")
+      assert.are.equal(node, node:strict())
+    end)
+
+    it(":passthrough() returns self", function()
+      local node = types.StringNode.new("x")
+      assert.are.equal(node, node:passthrough())
+    end)
+
+    it(":is_list() returns false for scalar nodes", function()
+      assert.is_false(types.StringNode.new():is_list())
+      assert.is_false(types.IntegerNode.new():is_list())
+      assert.is_false(types.BooleanNode.new():is_list())
+    end)
+  end)
+
+  -- =========================================================================
+  -- ObjectNode
+  -- =========================================================================
+
+  describe("ObjectNode", function()
+    it("materialize() returns a table with materialized child defaults", function()
+      local node = types.ObjectNode.new({
+        name = types.StringNode.new("alice"),
+        age = types.IntegerNode.new(30),
+      })
+      local result = node:materialize()
+      assert.is_table(result)
+      assert.are.equal("alice", result.name)
+      assert.are.equal(30, result.age)
+    end)
+
+    it("materialize() produces independent copies (schema reuse)", function()
+      local shared_string = types.StringNode.new("shared")
+      local schema = types.ObjectNode.new({
+        value = shared_string,
+      })
+      local result1 = schema:materialize()
+      local result2 = schema:materialize()
+      result1.value = "modified"
+      assert.are.equal("shared", result2.value)
+    end)
+
+    it("materialize() does not include symbol keys in output", function()
+      local node = types.ObjectNode.new({
+        name = types.StringNode.new("test"),
+        [symbols.ALIASES] = { alias_key = "name" },
+      })
+      local result = node:materialize()
+      assert.is_nil(result[symbols.ALIASES])
+      assert.are.equal("test", result.name)
+    end)
+
+    it("is_strict by default", function()
+      local node = types.ObjectNode.new({})
+      assert.is_true(node._strict)
+    end)
+
+    it(":strict() sets strict mode and returns self", function()
+      local node = types.ObjectNode.new({}):passthrough()
+      assert.is_false(node._strict)
+      local returned = node:strict()
+      assert.are.equal(node, returned)
+      assert.is_true(node._strict)
+    end)
+
+    it(":passthrough() disables strict mode and returns self", function()
+      local node = types.ObjectNode.new({})
+      local returned = node:passthrough()
+      assert.are.equal(node, returned)
+      assert.is_false(node._strict)
+    end)
+
+    it("stores _fields table with string-keyed fields only", function()
+      local name_node = types.StringNode.new("x")
+      local node = types.ObjectNode.new({
+        name = name_node,
+        [symbols.ALIASES] = { k = "name" },
+      })
+      assert.are.equal(name_node, node._fields.name)
+      assert.is_nil(node._fields[symbols.ALIASES])
+    end)
+
+    it("extracts aliases from symbols.ALIASES key", function()
+      local node = types.ObjectNode.new({
+        name = types.StringNode.new("x"),
+        [symbols.ALIASES] = { n = "name" },
+      })
+      assert.is_table(node._aliases)
+      assert.are.equal("name", node._aliases.n)
+    end)
+
+    it("extracts discover callback from symbols.DISCOVER key", function()
+      local discover_fn = function(_key)
+        return nil
+      end
+      local node = types.ObjectNode.new({
+        [symbols.DISCOVER] = discover_fn,
+      })
+      assert.are.equal(discover_fn, node._discover)
+    end)
+
+    it("resolve_alias() returns canonical path for known alias", function()
+      local node = types.ObjectNode.new({
+        real_field = types.StringNode.new("x"),
+        [symbols.ALIASES] = { short = "real_field" },
+      })
+      assert.are.equal("real_field", node:resolve_alias("short"))
+    end)
+
+    it("resolve_alias() returns nil for unknown key", function()
+      local node = types.ObjectNode.new({
+        real_field = types.StringNode.new("x"),
+        [symbols.ALIASES] = { short = "real_field" },
+      })
+      assert.is_nil(node:resolve_alias("unknown"))
+    end)
+
+    it("resolve_alias() returns nil when no aliases defined", function()
+      local node = types.ObjectNode.new({ field = types.StringNode.new("x") })
+      assert.is_nil(node:resolve_alias("field"))
+    end)
+
+    it(":is_list() returns false", function()
+      assert.is_false(types.ObjectNode.new({}):is_list())
+    end)
+
+    it("validate() returns true for a table value", function()
+      local node = types.ObjectNode.new({ x = types.StringNode.new("a") })
+      assert.is_true(node:validate({}))
+      assert.is_true(node:validate({ x = "hello" }))
+    end)
+
+    it("validate() returns false for non-table values", function()
+      local node = types.ObjectNode.new({})
+      assert.is_false(node:validate("string"))
+      assert.is_false(node:validate(42))
+    end)
+
+    it("materialize() recursively materializes nested objects", function()
+      local inner = types.ObjectNode.new({
+        value = types.IntegerNode.new(99),
+      })
+      local outer = types.ObjectNode.new({
+        inner = inner,
+      })
+      local result = outer:materialize()
+      assert.is_table(result.inner)
+      assert.are.equal(99, result.inner.value)
+    end)
+  end)
+
+  -- =========================================================================
+  -- ListNode
+  -- =========================================================================
+
+  describe("ListNode", function()
+    it("materialize() returns a deep copy of the default list", function()
+      local node = types.ListNode.new(types.StringNode.new(), { "a", "b" })
+      local result = node:materialize()
+      assert.are.same({ "a", "b" }, result)
+    end)
+
+    it("materialize() produces independent copies (schema reuse)", function()
+      local node = types.ListNode.new(types.StringNode.new(), { "a" })
+      local result1 = node:materialize()
+      local result2 = node:materialize()
+      table.insert(result1, "b")
+      assert.are.same({ "a" }, result2)
+    end)
+
+    it("materialize() returns empty list when no default provided", function()
+      local node = types.ListNode.new(types.StringNode.new())
+      local result = node:materialize()
+      assert.are.same({}, result)
+    end)
+
+    it(":is_list() returns true", function()
+      local node = types.ListNode.new(types.StringNode.new())
+      assert.is_true(node:is_list())
+    end)
+
+    it("validate() returns true for a table (list)", function()
+      local node = types.ListNode.new(types.StringNode.new())
+      assert.is_true(node:validate({}))
+      assert.is_true(node:validate({ "a", "b" }))
+    end)
+
+    it("validate() returns false for non-table values", function()
+      local node = types.ListNode.new(types.StringNode.new())
+      assert.is_false(node:validate("not a list"))
+      assert.is_false(node:validate(42))
+    end)
+
+    it("validate_item() delegates to item schema", function()
+      local node = types.ListNode.new(types.StringNode.new())
+      assert.is_true(node:validate_item("hello"))
+      assert.is_false(node:validate_item(42))
+    end)
+  end)
+
+  -- =========================================================================
+  -- MapNode
+  -- =========================================================================
+
+  describe("MapNode", function()
+    it("materialize() returns an empty table", function()
+      local node = types.MapNode.new(types.StringNode.new(), types.StringNode.new())
+      local result = node:materialize()
+      assert.is_table(result)
+      assert.are.same({}, result)
+    end)
+
+    it("validate() returns true for a table", function()
+      local node = types.MapNode.new(types.StringNode.new(), types.StringNode.new())
+      assert.is_true(node:validate({}))
+      assert.is_true(node:validate({ key = "value" }))
+    end)
+
+    it("validate() returns false for non-table values", function()
+      local node = types.MapNode.new(types.StringNode.new(), types.StringNode.new())
+      assert.is_false(node:validate("not a map"))
+      assert.is_false(node:validate(123))
+    end)
+
+    it(":is_list() returns false", function()
+      assert.is_false(types.MapNode.new(types.StringNode.new(), types.StringNode.new()):is_list())
+    end)
+  end)
+
+  -- =========================================================================
+  -- OptionalNode
+  -- =========================================================================
+
+  describe("OptionalNode", function()
+    it("validate() returns true for nil", function()
+      local node = types.OptionalNode.new(types.StringNode.new("x"))
+      assert.is_true(node:validate(nil))
+    end)
+
+    it("validate() returns true for values matching the inner schema", function()
+      local node = types.OptionalNode.new(types.StringNode.new("x"))
+      assert.is_true(node:validate("hello"))
+    end)
+
+    it("validate() returns false for values not matching the inner schema", function()
+      local node = types.OptionalNode.new(types.StringNode.new("x"))
+      assert.is_false(node:validate(42))
+    end)
+
+    it("materialize() returns the inner schema's default", function()
+      local node = types.OptionalNode.new(types.StringNode.new("inner_default"))
+      assert.are.equal("inner_default", node:materialize())
+    end)
+
+    it("materialize() returns nil when inner schema has no default", function()
+      local node = types.OptionalNode.new(types.StringNode.new())
+      assert.is_nil(node:materialize())
+    end)
+
+    it(":is_list() returns false", function()
+      assert.is_false(types.OptionalNode.new(types.StringNode.new()):is_list())
+    end)
+
+    it(":describe() and :type_as() chain correctly", function()
+      local node = types.OptionalNode.new(types.StringNode.new("x"))
+      assert.are.equal(node, node:describe("optional field"))
+      assert.are.equal(node, node:type_as("string|nil"))
+    end)
+  end)
+
+  -- =========================================================================
+  -- UnionNode
+  -- =========================================================================
+
+  describe("UnionNode", function()
+    it("validate() returns true when value matches first branch", function()
+      local node = types.UnionNode.new({ types.StringNode.new(), types.IntegerNode.new() })
+      assert.is_true(node:validate("hello"))
+    end)
+
+    it("validate() returns true when value matches second branch", function()
+      local node = types.UnionNode.new({ types.StringNode.new(), types.IntegerNode.new() })
+      assert.is_true(node:validate(42))
+    end)
+
+    it("validate() returns false when value matches no branch", function()
+      local node = types.UnionNode.new({ types.StringNode.new(), types.IntegerNode.new() })
+      assert.is_false(node:validate(true))
+      assert.is_false(node:validate({}))
+    end)
+
+    it("materialize() returns the first branch's default", function()
+      local node = types.UnionNode.new({ types.StringNode.new("first"), types.IntegerNode.new(99) })
+      assert.are.equal("first", node:materialize())
+    end)
+
+    it(":is_list() returns false", function()
+      assert.is_false(types.UnionNode.new({ types.StringNode.new() }):is_list())
+    end)
+  end)
+
+  -- =========================================================================
+  -- FuncNode
+  -- =========================================================================
+
+  describe("FuncNode", function()
+    it("validate() returns true for function values", function()
+      local node = types.FuncNode.new()
+      assert.is_true(node:validate(function() end))
+    end)
+
+    it("validate() returns false for non-function values", function()
+      local node = types.FuncNode.new()
+      assert.is_false(node:validate("not a function"))
+      assert.is_false(node:validate(42))
+      assert.is_false(node:validate({}))
+    end)
+
+    it("materialize() returns nil", function()
+      local node = types.FuncNode.new()
+      assert.is_nil(node:materialize())
+    end)
+
+    it(":is_list() returns false", function()
+      assert.is_false(types.FuncNode.new():is_list())
+    end)
+  end)
+
+  -- =========================================================================
+  -- LoadableNode
+  -- =========================================================================
+
+  describe("LoadableNode", function()
+    it("validate() returns true for dotted module path strings", function()
+      local node = types.LoadableNode.new()
+      assert.is_true(node:validate("flemma.config"))
+      assert.is_true(node:validate("some.module.path"))
+    end)
+
+    it("validate() returns false for plain non-dotted strings", function()
+      local node = types.LoadableNode.new()
+      assert.is_false(node:validate("nodots"))
+      assert.is_false(node:validate(""))
+      assert.is_false(node:validate(42))
+    end)
+
+    it("validate() returns false for non-string values", function()
+      local node = types.LoadableNode.new()
+      assert.is_false(node:validate(42))
+      assert.is_false(node:validate({}))
+      assert.is_false(node:validate(nil))
+    end)
+
+    it("materialize() returns nil", function()
+      local node = types.LoadableNode.new()
+      assert.is_nil(node:materialize())
+    end)
+
+    it(":is_list() returns false", function()
+      assert.is_false(types.LoadableNode.new():is_list())
+    end)
+  end)
+
+  -- =========================================================================
+  -- Schema reuse independence
+  -- =========================================================================
+
+  describe("schema reuse", function()
+    it("shared ObjectNode sub-schema produces independent materializations", function()
+      local shared_schema = types.ObjectNode.new({
+        count = types.IntegerNode.new(0),
+      })
+      local parent = types.ObjectNode.new({
+        child_a = shared_schema,
+        child_b = shared_schema,
+      })
+      local result = parent:materialize()
+      result.child_a.count = 999
+      assert.are.equal(0, result.child_b.count)
+    end)
+
+    it("shared ListNode produces independent materializations", function()
+      local shared_list = types.ListNode.new(types.StringNode.new(), { "item" })
+      local parent = types.ObjectNode.new({
+        list_a = shared_list,
+        list_b = shared_list,
+      })
+      local result = parent:materialize()
+      table.insert(result.list_a, "extra")
+      assert.are.same({ "item" }, result.list_b)
+    end)
+  end)
+end)

--- a/tests/flemma/config/schema_spec.lua
+++ b/tests/flemma/config/schema_spec.lua
@@ -4,6 +4,7 @@ describe("flemma.config.schema.types", function()
   local types
 
   before_each(function()
+    package.loaded["flemma.config.schema"] = nil
     package.loaded["flemma.config.schema.types"] = nil
     types = require("flemma.config.schema.types")
   end)


### PR DESCRIPTION
## Summary

- Replace Flemma's fragmented config subsystem (`config.lua` + `buffer/opt.lua` + `core/config/manager.lua` + `set_parameter_overrides`) with a unified, layered copy-on-write config store backed by a declarative schema DSL
- Schema defines all structure, types, and defaults. Layer store records operations (set/append/remove/prepend) per layer (defaults, setup, runtime, frontmatter). Proxy metatables provide natural Lua read/write access. Frozen lenses give consumers scoped, read-only views
- Entire codebase switches from threading `frontmatter_opts` to calling `config.get(bufnr)`

## Progress

Phase 1: Build the config module (Tasks 1-9)

- [x] Task 1: Add `ALIASES` and `DISCOVER` symbols
- [x] Task 2: Schema node types (types.lua + 74 tests)
- [x] Task 3: Schema DSL factory (init.lua)
- [x] Task 4: Layer store (core resolution engine)
- [x] Task 5: Proxy metatables (read, write, list, frozen)
- [x] Task 6: Alias resolution
- [x] Task 7: DISCOVER lazy schema resolution
- [x] Task 8: Composed lenses
- [x] Task 9: Public API module

Phase 2: Migrate the codebase (Tasks 10-23)

- [x] Task 10-12: Schema definition + provider/tool config schemas
- [ ] Task 13-18: Rewire setup, frontmatter, core, tools, sandbox, providers
- [ ] Task 19-21: Rewire status, migrate consumers, rewire runtime commands
- [ ] Task 22-23: Remove old modules, final QA

## Test plan

- [ ] All 8 new config test suites pass (schema, store, proxy, alias, list_ops, discover, lens, integration)
- [ ] All existing tests continue to pass after migration
- [ ] `make qa` green at every task boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)